### PR TITLE
allow admins/mods to view anonymous post authors

### DIFF
--- a/src/controllers/recent.js
+++ b/src/controllers/recent.js
@@ -35,13 +35,13 @@ recentController.getData = async function (req, url, sort, selectedTerm = 'allti
 
 	//get priveleges
 	const [settings, categoryData, tagData, rssToken, canPost, isPrivileged] = await Promise.all([
-        user.getSettings(req.uid),
-        helpers.getSelectedCategory(cid),
-        helpers.getSelectedTag(tag),
-        user.auth.getFeedToken(req.uid),
-        privileges.categories.canPostTopic(req.uid),
-        user.isPrivileged(req.uid),
-    ]);
+		user.getSettings(req.uid),
+		helpers.getSelectedCategory(cid),
+		helpers.getSelectedTag(tag),
+		user.auth.getFeedToken(req.uid),
+		privileges.categories.canPostTopic(req.uid),
+		user.isPrivileged(req.uid),
+	]);
 
 	const start = Math.max(0, (page - 1) * settings.topicsPerPage);
 	const stop = start + settings.topicsPerPage - 1;
@@ -60,26 +60,26 @@ recentController.getData = async function (req, url, sort, selectedTerm = 'allti
 	});
 
 	// If the viewer is not privileged (Admin/Mod), make anonymous 
-    if (!isPrivileged && data.topics) {
-        data.topics.forEach((topic) => {
+	if (!isPrivileged && data.topics) {
+		data.topics.forEach((topic) => {
 			//srub the topic starter
-            if (topic.anonymous && topic.user) {
-                topic.user.username = 'Anonymous';
-                topic.user.userslug = '';
-                topic.user.picture = '';
-                topic.user['icon:text'] = '?';
-                topic.user['icon:bgColor'] = '#666';
-            }
+			if (topic.anonymous && topic.user) {
+				topic.user.username = 'Anonymous';
+				topic.user.userslug = '';
+				topic.user.picture = '';
+				topic.user['icon:text'] = '?';
+				topic.user['icon:bgColor'] = '#666';
+			}
 			//scrub the last reply
-            if (topic.teaser && topic.teaser.anonymous && topic.teaser.user) {
-                topic.teaser.user.username = 'Anonymous';
-                topic.teaser.user.userslug = '';
-                topic.teaser.user.picture = '';
-                topic.teaser.user['icon:text'] = '?';
-                topic.teaser.user['icon:bgColor'] = '#666';
-            }
-        });
-    }
+			if (topic.teaser && topic.teaser.anonymous && topic.teaser.user) {
+				topic.teaser.user.username = 'Anonymous';
+				topic.teaser.user.userslug = '';
+				topic.teaser.user.picture = '';
+				topic.teaser.user['icon:text'] = '?';
+				topic.teaser.user['icon:bgColor'] = '#666';
+			}
+		});
+	}
 
 	const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/${url}`) || req.originalUrl.startsWith(`${relative_path}/${url}`));
 	const baseUrl = isDisplayedAsHome ? '' : url;


### PR DESCRIPTION
This change is part of User Story 1 (Anonymous Posting). While students need to post anonymously, Administrators and Moderators retain the ability to see the original author for moderation and safety purposes. This PR implements the backend logic to conditionally hide or reveal the author.

Description: I modified the post retrieval logic to check the viewer's permissions before sending the post data to the client.

Retrieves the current user's privilege level (Admin/Global Mod).

Checks if the post has the anonymous flag set (from Task 1).

If the post is anonymous, the username and avatar are replaced with "Anonymous" placeholders.

If the user is admin/mod they see the original data.

Changes

Modified: src/posts/data.js (Added conditional logic to getPostData) and added user.isAdministrator(uid) check.